### PR TITLE
Skip verify_authenticity_token on session destroy

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,5 +1,6 @@
 class SessionsController < ApplicationController
   skip_before_action :require_authentication, only: [:new, :create]
+  skip_before_action :verify_authenticity_token, only: [:destroy]
 
   def new
     redirect_to root_url if authenticated_user


### PR DESCRIPTION
Upon signing out, don't verify the authenticity token because of the
fact the session could already be timed out. In any case, the preference
is to have the sign out work no matter what.